### PR TITLE
Bumped installer to v1.5.10

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -eu
-VAMP_INSTALLER_VERSION=1.5.9
+VAMP_INSTALLER_VERSION=1.5.10
 VAMP_INSTALLER_IMAGE=${DEFAULT_VAMP_INSTALLER_IMAGE:=vampio/k8s-installer:$VAMP_INSTALLER_VERSION}
 VAMP_INSTALLER_BOOTSTRAP_YAML=${DEFAULT_VAMP_BOOTSTRAP_YAML:=https://raw.githubusercontent.com/magneticio/vamp-cloud-installer/master/bootstrap-policy.yaml}
 


### PR DESCRIPTION
Controller
- v3.0.6 (Improved NATS connection check)
- Added liveness and readiness probes
RA
- v12.5.1 (Improvements to the OpenTelemetry support)