### PR TITLE
LAM-2214 Exit customer-run script with the exit code of the installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+version: "2.1"
+
+workflows:
+  smoke-test:
+    jobs:
+      - smoke-test
+
+jobs:
+  smoke-test:
+    docker:
+      - image: alpine:3.13
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            apk update && apk add bash
+
+            # We need bats 1.3.0 at least to be able to use
+            # `--report-formatter` and `--formatter` options.
+            #
+            # It's not great to rely on a package from edge, it could change any time.
+            #
+            # When the current Alpine release contains bats >= 1.3.0, `bats`
+            # should be added to the standard apk add above, and this should be
+            # removed.
+            echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+            apk add bats@testing
+      - run:
+          name: Test
+          command: bats --report-formatter junit --formatter tap test/
+      - store_test_results:
+          path: report.xml

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 Vamp Cloud Agent Installer for Kubernetes
 
 Invoke the installer as described here: https://docs.vamp.cloud/release-agent/installation#installing-the-release-agent
+
+## Automated Testing
+
+Tests are written using the [bats](https://github.com/bats-core/bats-core) testing framework.
+Bats can be installed in macos via homebrew with `brew install bats-core`, see the bats documentation for [installation on other operating systems](https://bats-core.readthedocs.io/en/latest/installation.html).
+
+Test files should be written to the `test/` directory and given the extenion `.bats`.
+
+### Running the tests
+
+Invoke `bats` from the root directory of the checkout
+```
+$ bats test/
+```

--- a/test-scripts/kubectl
+++ b/test-scripts/kubectl
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Fake `kubectl` script used for testing install.sh
+# 
+# This script will exit 0 for all kubectl commands, with the exception of `kubectl exec`.
+# It makes use of the extra arguments that can be passed to install.sh which
+# are passed through to `kubectl exec` to allow control over the exit code.
+
+_command=$1
+shift
+
+case "${_command}" in
+  exec)
+    _extra_args=$6
+    if [ "XfailX" = "X${_extra_args}X" ]; then
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac

--- a/test/smoketest.bats
+++ b/test/smoketest.bats
@@ -1,0 +1,29 @@
+set -eu
+
+# Vamp installer smoke-test.
+#
+# Uses a fake `kubectl` command
+
+_fake_kubectl=./test-scripts/kubectl
+if [ ! -f "${_fake_kubectl}" ]; then
+  echo "Required support script ${_fake_kubectl} wasn't found. This script is used to fake kubectl in tests to prevent accidental modifying of real Kubernetes clusters, so tests will refuse to run without it."
+  exit 1
+fi
+
+setup() {
+  PATH="./test-scripts/:${PATH}"
+}
+
+@test "a successful install exits zero" {
+  sh install.sh
+  local status=$?
+  [ "$status" -eq 0 ]
+}
+
+@test "an unsuccessful install exits nonzero" {
+  set +e
+  sh install.sh fail
+  local status=$?
+  set -e
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
* Trigger cleanup on script exit via `trap`

Questions for the Vamp folks
1. ~There's no test harness here, I've "tested" this by targeting a local `minikube` but would prefer something automated. Is there an automated test further downstream?~ Added a basic smoketest.
2. `cleanup` makes the assumption that it's always safe to execute the cleanup commands, regardless of cluster state. Does that assumption hold?
3. How does this get deployed?
4. Is this script intended to be POSIX sh?
