### PR TITLE
Bumped up installer version to 1.13.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VAMP_INSTALLER_VERSION=1.13.1
+VAMP_INSTALLER_VERSION=1.13.2
 VAMP_INSTALLER_IMAGE=${DEFAULT_VAMP_INSTALLER_IMAGE:=vampio/k8s-installer:$VAMP_INSTALLER_VERSION}
 VAMP_INSTALLER_BOOTSTRAP_YAML=${DEFAULT_VAMP_BOOTSTRAP_YAML:=https://raw.githubusercontent.com/magneticio/vamp-cloud-installer/master/bootstrap-policy.yaml}
 


### PR DESCRIPTION
Installer version `1.13.2` removes `hostPort`s from Deployment Controller and Release Agent deployment YAMLs.