### PR TITLE
REL-415 Use Pod resource spec to launch vamp-cloud-installer pod

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,19 @@ echo "Vamp Cloud Installer: $VAMP_INSTALLER_VERSION"
 kubectl apply -f "$VAMP_INSTALLER_BOOTSTRAP_YAML"
 
 # Run nats-setup container containing the latest set of manifests.
-kubectl run vamp-cloud-installer --image-pull-policy=Always --serviceaccount=vamp-cloud-installer --image=$VAMP_INSTALLER_IMAGE --restart=Never
+kubectl apply -f - << _EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vamp-cloud-installer
+spec:
+  containers:
+  - name: vamp-cloud-installer
+    image: $VAMP_INSTALLER_IMAGE
+    imagePullPolicy: Always
+  restartPolicy: Never
+  serviceAccount: vamp-cloud-installer
+_EOF
 
 # Wait for the setup container to start or bail.
 kubectl wait --for=condition=Ready pod/vamp-cloud-installer --timeout=30s


### PR DESCRIPTION
Recent (1.22.x) `kubectl` client binaries mention that the
--serviceaccount flag for the `run` command is deprecated and ignore it.
```
Flag --serviceaccount has been deprecated, has no effect and will be removed in the future.
```

Replace `kubectl run` with creating the `vamp-cloud-installer` pod from
a pod resource YAML.

Tested on a local Kubernetes cluster.