### PR TITLE
REL-425: add perms for ingressannotations/status + bump version

### DIFF
--- a/bootstrap-policy.yaml
+++ b/bootstrap-policy.yaml
@@ -102,6 +102,7 @@ rules:
 - apiGroups: ["vamp.io"]
   resources:
   - ingressannotations
+  - ingressannotations/status
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["projectcontour.io"]
   resources: ["httpproxies"]

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-VAMP_INSTALLER_VERSION=3.0.12
+VAMP_INSTALLER_VERSION=3.0.13
 VAMP_INSTALLER_IMAGE=${DEFAULT_VAMP_INSTALLER_IMAGE:=vampio/k8s-installer:$VAMP_INSTALLER_VERSION}
 VAMP_INSTALLER_BOOTSTRAP_YAML=${DEFAULT_VAMP_BOOTSTRAP_YAML:=https://raw.githubusercontent.com/magneticio/vamp-cloud-installer/master/bootstrap-policy.yaml}
 


### PR DESCRIPTION
Installer script needs RBAC permission for `ingressannotations/status` resource to be able to grant this permission to `vamp-k8s-controller` role.